### PR TITLE
Bump up bundle with

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -224,4 +224,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   2.0.1
+   2.1.4


### PR DESCRIPTION
ローカルのbundlerのバージョン違いで`bundle install`できないため
```
$ bundle install
Traceback (most recent call last):
        2: from /Users/user_name/.rbenv/versions/2.5.1/bin/bundle:23:in `<main>'
        1: from /Users/yuki.watanabe/.rbenv/versions/2.5.1/lib/ruby/2.5.0/rubygems.rb:308:in `activate_bin_path'
/Users/user_name/.rbenv/versions/2.5.1/lib/ruby/2.5.0/rubygems.rb:289:in `find_spec_for_exe': can't find gem bundler (>= 0.a) with executable bundle (Gem::GemNotFoundException)
```